### PR TITLE
add demo translation file and directory

### DIFF
--- a/.i18nrc.json
+++ b/.i18nrc.json
@@ -3,5 +3,5 @@
   "paths": {
       "i18nPlugin": "."
   },
-  "translations": ["translations/zh-CN.json"]
+  "translations": ["translations/demo.json"]
 }

--- a/translations/demo.json
+++ b/translations/demo.json
@@ -1,0 +1,97 @@
+{
+    "formats": {
+      "number": {
+        "currency": {
+          "style": "currency"
+        },
+        "percent": {
+          "style": "percent"
+        }
+      },
+      "date": {
+        "short": {
+          "month": "numeric",
+          "day": "numeric",
+          "year": "2-digit"
+        },
+        "medium": {
+          "month": "short",
+          "day": "numeric",
+          "year": "numeric"
+        },
+        "long": {
+          "month": "long",
+          "day": "numeric",
+          "year": "numeric"
+        },
+        "full": {
+          "weekday": "long",
+          "month": "long",
+          "day": "numeric",
+          "year": "numeric"
+        }
+      },
+      "time": {
+        "short": {
+          "hour": "numeric",
+          "minute": "numeric"
+        },
+        "medium": {
+          "hour": "numeric",
+          "minute": "numeric",
+          "second": "numeric"
+        },
+        "long": {
+          "hour": "numeric",
+          "minute": "numeric",
+          "second": "numeric",
+          "timeZoneName": "short"
+        },
+        "full": {
+          "hour": "numeric",
+          "minute": "numeric",
+          "second": "numeric",
+          "timeZoneName": "short"
+        }
+      },
+      "relative": {
+        "years": {
+          "units": "year"
+        },
+        "months": {
+          "units": "month"
+        },
+        "days": {
+          "units": "day"
+        },
+        "hours": {
+          "units": "hour"
+        },
+        "minutes": {
+          "units": "minute"
+        },
+        "seconds": {
+          "units": "second"
+        }
+      }
+    },
+    "messages": {
+      "console.devToolsDescription": "跳过 cURL 并使用 JSON 接口在控制台中处理您的数据。",
+      "console.devToolsTitle": "与 OpenSearch API 进行交互",
+      "core.ui.welcomeMessage": "正在加载 OpenSearch",
+      "dashboard.featureCatalogue.dashboardSubtitle": "在控制板中分析数据。",
+      "discover.discoverSubtitle": "搜索和查找数据分析结果。",
+      "home.addData.sectionTitle": "获取你的数据",
+      "home.breadcrumbs.homeTitle": "主页",
+      "home.header.title": "欢迎归来",
+      "home.manageData.sectionTitle": "管理你的数据",
+      "home.tutorialDirectory.featureCatalogueDescription": "从热门应用和服务中采集数据。",
+      "home.tutorialDirectory.featureCatalogueTitle": "添加数据",
+      "opensearchDashboardsOverview.opensearchDashboards.solution.subtitle": "可视化和分析",
+      "opensearch-dashboards-react.osdOverviewPageHeader.addDataButtonLabel": "添加数据",
+      "opensearch-dashboards-react.osdOverviewPageHeader.devToolsButtonLabel": "开发工具",
+      "opensearch-dashboards-react.osdOverviewPageHeader.stackManagementButtonLabel": "管理",
+      "opensearch-dashboards-react.pageFooter.appDirectoryButtonLabel": "查看应用目录",
+      "opensearch-dashboards-react.pageFooter.changeHomeRouteLink": "登录时显示不同页面"
+    }
+  }


### PR DESCRIPTION
### Description
* add a demo file which will show an example translation of the loading page and home page
* modify translation path `"translations": ["translations/zh-CN.json"]` to point to the demo file

### Issues Resolved
https://github.com/opensearch-project/i18n-plugin/issues/2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
