### PR TITLE
Fix the plugin's build issues

### DIFF
--- a/.opensearch_dashboards-plugin-helpers.json
+++ b/.opensearch_dashboards-plugin-helpers.json
@@ -1,0 +1,10 @@
+{
+  "buildSourcePatterns": [
+    ".i18nrc.json",
+    "yarn.lock",
+    "tsconfig.json",
+    "package.json",
+    "index.{js,ts}",
+    "{common,lib,server,webpackShims,translations,utils,target}/**/*"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "../../scripts/use_node ../../scripts/eslint .",
     "update-version": "../../scripts/use_node scripts/update_opensearch_dashboards_version.js",
-    "plugin-helpers": "../../scripts/use_node ../../scripts/plugin_helpers"
+    "plugin-helpers": "../../scripts/use_node ../../scripts/plugin_helpers",
+    "build": "yarn plugin-helpers build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description
[Describe what this change achieves]

I made the following changes to fix the issue where the internationalization plugin couldn't be used after building:

1. Added a build command in package.json. This allows for quick calls to osd/plugin-helper to build and package the plugin.
2. Created an .opensearch_dashboards-plugin-helpers.json configuration file. This ensures that essential modules, such as the .i18nrc.json file, are included in the build output during the build and packaging process.

After these changes, using the internationalization plugin is straightforward. Simply run yarn build within the plugin. Then, unzip the build directory's package and place it in the plugins folder of the opensearch-dashboards build output. The final result is shown below.

![image](https://github.com/user-attachments/assets/70f7c8ab-5a2b-4b9b-87ac-e9a573c3ec86)

![image](https://github.com/user-attachments/assets/65432974-ed48-45c5-93b2-33e2068259cf)


### Issues Resolved
[List any issues this PR will resolve]

Solve the old old problems 👇

https://github.com/opensearch-project/dashboards-i18n/issues/14

https://github.com/opensearch-project/dashboards-i18n/issues/30

### Check List
- [ ] New locale: New [issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues) has been opened in OpenSearch Dashboards for support.
- [ ] New locale: [DEVELOPER_GUIDE](https://github.com/opensearch-project/dashboards-i18n/blob/main/DEVELOPER_GUIDE.md#new-locale:~:text=are%20correctly%20translated.-,New%20locale,-Currently%2C%20we%20support) has been updated.
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
